### PR TITLE
Fixed NullSmsSender.cs

### DIFF
--- a/source/src/MyTelegram.SmsSender/NullSmsSender.cs
+++ b/source/src/MyTelegram.SmsSender/NullSmsSender.cs
@@ -2,7 +2,7 @@
 
 public class NullSmsSender(ILogger<NullSmsSender> logger) : INullSmsSender, ITransientDependency
 {
-    public bool Enabled => true;
+    public bool Enabled => false;
     public Task SendAsync(SmsMessage smsMessage)
     {
         logger.LogWarning("NullSMsSender: the code will not be sent.PhoneNumber:{To} Text:{Text}", smsMessage.PhoneNumber, smsMessage.Text);


### PR DESCRIPTION
When ullSmsSender is enabled, SMS messages are randomly sent by the NullSmsSender and the SMS provider.