### PR TITLE
Fixed Docker Compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ MyTelegram is telegram server side api implementation written in c#, support pri
 3. Run the following command in the directory where the docker-compose.yml file is located
    ```
       mkdir -p ./data/mytelegram
-      chmod -R 777 ./data/mytelegram
+      chown -R 1654:1654 ./data/mytelegram
       docker compose up
    ```
 4. Default verification code is `22222`
@@ -78,3 +78,4 @@ Contact author: [https://t.me/mytelegram666](https://t.me/mytelegram666)
 MyTelegram channel: [https://t.me/+9wMJrMqLTIoyYzM8](https://t.me/+9wMJrMqLTIoyYzM8)
 
 Mytelegram discussion group: [https://t.me/+S-aNBoRvCRpPyXrR](https://t.me/+S-aNBoRvCRpPyXrR)
+

--- a/docker/compose/docker-compose.yml
+++ b/docker/compose/docker-compose.yml
@@ -115,7 +115,8 @@ services:
     volumes:
       - ./data/mytelegram/data-seeder/logs:/app/Logs
     depends_on:
-      - mongodb
+      mongodb:
+        condition: service_healthy
 
   ### 1.Gateway server
   gateway-server:
@@ -203,9 +204,12 @@ services:
       RabbitMQ__EventBus__ClientName: ${RabbitMQ__EventBus__ClientName}
       RabbitMQ__EventBus__ExchangeName: ${RabbitMQ__EventBus__ExchangeName}
     depends_on:
-      - rabbitmq
-      - mongodb
-      - redis
+      rabbitmq:
+        condition: service_healthy
+      mongodb:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
 
   # ### 2.Seq server
   # seq-server:
@@ -242,9 +246,12 @@ services:
     volumes:
       - ./data/mytelegram/auth/logs:/app/Logs
     depends_on:
-      - mongodb
-      - rabbitmq
-      - redis
+      mongodb:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
 
   ### 3.Session server
   session-server:
@@ -275,9 +282,12 @@ services:
     volumes:
       - ./data/mytelegram/session/logs:/app/Logs
     depends_on:
-      - mongodb
-      - rabbitmq
-      - redis
+      mongodb:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
 
   # ### 5.Messenger grpc server
   # messenger-grpc-server:
@@ -326,8 +336,10 @@ services:
       RabbitMQ__EventBus__ExchangeName: ${RabbitMQ__EventBus__ExchangeName}
       Redis__Configuration: ${Redis__Configuration}
     depends_on:
-      - mongodb
-      - rabbitmq
+      mongodb:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
 
   ### 5.Messenger command server
   messenger-command-server:
@@ -416,9 +428,12 @@ services:
     volumes:
       - ./data/mytelegram/command-server/logs:/app/Logs
     depends_on:
-      - mongodb
-      - rabbitmq
-      - redis
+      mongodb:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
 
   ### 6.Messenger query server
   messenger-query-server:
@@ -506,9 +521,12 @@ services:
     volumes:
       - ./data/mytelegram/query-server/logs:/app/Logs
     depends_on:
-      - mongodb
-      - rabbitmq
-      - redis
+      mongodb:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
 
   ### 7.Sms sender
   sms-sender:
@@ -536,4 +554,5 @@ services:
     volumes:
       - ./data/mytelegram/sms-sender/logs:/app/Logs
     depends_on:
-      - rabbitmq
+      rabbitmq:
+        condition: service_healthy

--- a/docker/compose/docker-compose.yml
+++ b/docker/compose/docker-compose.yml
@@ -7,7 +7,7 @@ networks:
 services:
   ### Redis
   redis:
-    image: redis:alpine
+    image: redis:8-alpine
     restart: always
     networks:
       - tg-net
@@ -15,6 +15,16 @@ services:
     #- "6379:6379"
     volumes:
       - ./data/redis:/data
+    command: ["redis-server", "--appendonly", "yes", "--save", "60", "1000"]
+    # Optional auth:
+    # command: ["redis-server", "--appendonly", "yes", "--save", "60", "1000", "--requirepass", "${REDIS_PASSWORD}"]
+    # environment:
+    #   REDIS_PASSWORD: ${Redis__Password:-changeme}
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
 
   ### RabbitMq
   rabbitmq:
@@ -28,26 +38,34 @@ services:
     volumes:
       - ./data/rabbitmq:/var/lib/rabbitmq
     environment:
-      # RABBITMQ_DEFAULT_USER: ${RabbitMQ__Connections__Default__UserName}
-      # RABBITMQ_DEFAULT_PASS: ${RabbitMQ__Connections__Default__Password}
-      RABBITMQ_DEFAULT_USER: test
-      RABBITMQ_DEFAULT_PASS: test
+      RABBITMQ_DEFAULT_USER: ${RabbitMQ__Connections__Default__UserName:-test}
+      RABBITMQ_DEFAULT_PASS: ${RabbitMQ__Connections__Default__Password:-test}
+      RABBITMQ_ERLANG_COOKIE: ${RabbitMQ__ErlangCookie:-changeme-cookie}
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "-q", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   ### MongoDb
   mongodb:
-    image: mongo:latest
+    image: mongo:8
     restart: always
     networks:
       - tg-net
     #ports:
     #  - "27017:27017"
     volumes:
-      - ./data/mongo/:/data
-      #- ./data/mongo/db:/data/db
-      #- ./data/mongo/configdb:/data/configdb
-    #environment:
-    #  MONGO_INITDB_ROOT_USERNAME: admin
-    #  MONGO_INITDB_ROOT_PASSWORD: admin
+      - ./data/mongo/db:/data/db
+      - ./data/mongo/configdb:/data/configdb
+    # environment:
+    #   MONGO_INITDB_ROOT_USERNAME: ${Mongo__User:-root}
+    #   MONGO_INITDB_ROOT_PASSWORD: ${Mongo__Password:-rootpass}
+    healthcheck:
+      test: ["CMD", "mongosh", "--quiet", "--eval", "db.adminCommand({ ping: 1 })"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   ### Minio
   minio:
@@ -55,9 +73,7 @@ services:
     restart: always
     networks:
       - tg-net
-    #expose:
-    #  - "9000"
-    #  - "9001"
+
     #ports:
     #  - 9000:9000
     #  - 9001:9001
@@ -67,8 +83,13 @@ services:
     volumes:
       - ./data/minio:/data
       #- /docker/minio/config:/root/./minio/
-    command: server /data  --console-address ":9001"
-    #privileged: true
+    command: server /data --console-address ":9001"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+
 
   ################### MyTelegram server
 
@@ -85,12 +106,12 @@ services:
       App__ReadModelDatabaseName: ${App__ReadModelDatabaseName}
       App__CreateTestUsers: ${App__CreateTestUsers}
       # App__LoadAllStickersIntoMemory: ${App__LoadAllStickersIntoMemory}
-      RabbitMQ__Connections__Default__HostName: ${RabbitMQ__Connections__Default__HostName}
-      # RabbitMQ__Connections__Default__Port: ${RabbitMQ__Connections__Default__Port}
-      # RabbitMQ__Connections__Default__UserName: ${RabbitMQ__Connections__Default__UserName}
-      # RabbitMQ__Connections__Default__Password: ${RabbitMQ__Connections__Default__Password}
-      # RabbitMQ__EventBus__ClientName: ${RabbitMQ__EventBus__ClientName}
-      # RabbitMQ__EventBus__ExchangeName: ${RabbitMQ__EventBus__ExchangeName}
+      RabbitMQ__Connections__Default__HostName: ${RabbitMQ__Connections__Default__HostName:-rabbitmq}
+      RabbitMQ__Connections__Default__Port: ${RabbitMQ__Connections__Default__Port:-5672}
+      RabbitMQ__Connections__Default__UserName: ${RabbitMQ__Connections__Default__UserName:-test}
+      RabbitMQ__Connections__Default__Password: ${RabbitMQ__Connections__Default__Password:-test}
+      RabbitMQ__EventBus__ClientName: ${RabbitMQ__EventBus__ClientName}
+      RabbitMQ__EventBus__ExchangeName: ${RabbitMQ__EventBus__ExchangeName}
     volumes:
       - ./data/mytelegram/data-seeder/logs:/app/Logs
     depends_on:
@@ -175,12 +196,12 @@ services:
       # App__Servers__5__KeyPemFilePath: ${App__Servers__5__KeyPemFilePath}
       # App__Servers__5__EnableProxyProtocolV2: ${App__Servers__5__EnableProxyProtocolV2}
       # App__Servers__5__MediaOnly: ${App__Servers__5__MediaOnly}
-      RabbitMQ__Connections__Default__HostName: ${RabbitMQ__Connections__Default__HostName}
-      # RabbitMQ__Connections__Default__Port: ${RabbitMQ__Connections__Default__Port}
-      # RabbitMQ__Connections__Default__UserName: ${RabbitMQ__Connections__Default__UserName}
-      # RabbitMQ__Connections__Default__Password: ${RabbitMQ__Connections__Default__Password}
-      # RabbitMQ__EventBus__ClientName: ${RabbitMQ__EventBus__ClientName}
-      # RabbitMQ__EventBus__ExchangeName: ${RabbitMQ__EventBus__ExchangeName}
+      RabbitMQ__Connections__Default__HostName: ${RabbitMQ__Connections__Default__HostName:-rabbitmq}
+      RabbitMQ__Connections__Default__Port: ${RabbitMQ__Connections__Default__Port:-5672}
+      RabbitMQ__Connections__Default__UserName: ${RabbitMQ__Connections__Default__UserName:-test}
+      RabbitMQ__Connections__Default__Password: ${RabbitMQ__Connections__Default__Password:-test}
+      RabbitMQ__EventBus__ClientName: ${RabbitMQ__EventBus__ClientName}
+      RabbitMQ__EventBus__ExchangeName: ${RabbitMQ__EventBus__ExchangeName}
     depends_on:
       - rabbitmq
       - mongodb
@@ -211,12 +232,12 @@ services:
     environment:
       Serilog__MinimumLevel__Default: ${Serilog__MinimumLevel__Default}
       #App__PrivateKeyFilePath: ${App__PrivateKeyFilePath}
-      RabbitMQ__Connections__Default__HostName: ${RabbitMQ__Connections__Default__HostName}
-      # RabbitMQ__Connections__Default__Port: ${RabbitMQ__Connections__Default__Port}
-      # RabbitMQ__Connections__Default__UserName: ${RabbitMQ__Connections__Default__UserName}
-      # RabbitMQ__Connections__Default__Password: ${RabbitMQ__Connections__Default__Password}
-      # RabbitMQ__EventBus__ClientName: ${RabbitMQ__EventBus__ClientName}
-      # RabbitMQ__EventBus__ExchangeName: ${RabbitMQ__EventBus__ExchangeName}
+      RabbitMQ__Connections__Default__HostName: ${RabbitMQ__Connections__Default__HostName:-rabbitmq}
+      RabbitMQ__Connections__Default__Port: ${RabbitMQ__Connections__Default__Port:-5672}
+      RabbitMQ__Connections__Default__UserName: ${RabbitMQ__Connections__Default__UserName:-test}
+      RabbitMQ__Connections__Default__Password: ${RabbitMQ__Connections__Default__Password:-test}
+      RabbitMQ__EventBus__ClientName: ${RabbitMQ__EventBus__ClientName}
+      RabbitMQ__EventBus__ExchangeName: ${RabbitMQ__EventBus__ExchangeName}
       Redis__Configuration: ${Redis__Configuration}
     volumes:
       - ./data/mytelegram/auth/logs:/app/Logs
@@ -244,12 +265,12 @@ services:
       # App__DispatchUnknownObjectToMessengerServer: ${App__DispatchUnknownObjectToMessengerServer}
       # App__TempAuthKeyExpirationMinutes: ${App__TempAuthKeyExpirationMinutes}
       # App__CommandServerObjectIds: ${App__CommandServerObjectIds}
-      RabbitMQ__Connections__Default__HostName: ${RabbitMQ__Connections__Default__HostName}
-      # RabbitMQ__Connections__Default__Port: ${RabbitMQ__Connections__Default__Port}
-      # RabbitMQ__Connections__Default__UserName: ${RabbitMQ__Connections__Default__UserName}
-      # RabbitMQ__Connections__Default__Password: ${RabbitMQ__Connections__Default__Password}
-      # RabbitMQ__EventBus__ClientName: ${RabbitMQ__EventBus__ClientName}
-      # RabbitMQ__EventBus__ExchangeName: ${RabbitMQ__EventBus__ExchangeName}
+      RabbitMQ__Connections__Default__HostName: ${RabbitMQ__Connections__Default__HostName:-rabbitmq}
+      RabbitMQ__Connections__Default__Port: ${RabbitMQ__Connections__Default__Port:-5672}
+      RabbitMQ__Connections__Default__UserName: ${RabbitMQ__Connections__Default__UserName:-test}
+      RabbitMQ__Connections__Default__Password: ${RabbitMQ__Connections__Default__Password:-test}
+      RabbitMQ__EventBus__ClientName: ${RabbitMQ__EventBus__ClientName}
+      RabbitMQ__EventBus__ExchangeName: ${RabbitMQ__EventBus__ExchangeName}
       Redis__Configuration: ${Redis__Configuration}
     volumes:
       - ./data/mytelegram/session/logs:/app/Logs
@@ -297,12 +318,12 @@ services:
       Minio__SecretKey: ${Minio__SecretKey}
       # Minio__BucketName: ${Minio__BucketName}
       # Minio__CreateBucketIfNotExists: ${Minio__CreateBucketIfNotExists}
-      RabbitMQ__Connections__Default__HostName: ${RabbitMQ__Connections__Default__HostName}
-      # RabbitMQ__Connections__Default__Port: ${RabbitMQ__Connections__Default__Port}
-      # RabbitMQ__Connections__Default__UserName: ${RabbitMQ__Connections__Default__UserName}
-      # RabbitMQ__Connections__Default__Password: ${RabbitMQ__Connections__Default__Password}
-      # RabbitMQ__EventBus__ClientName: ${RabbitMQ__EventBus__ClientName}
-      # RabbitMQ__EventBus__ExchangeName: ${RabbitMQ__EventBus__ExchangeName}
+      RabbitMQ__Connections__Default__HostName: ${RabbitMQ__Connections__Default__HostName:-rabbitmq}
+      RabbitMQ__Connections__Default__Port: ${RabbitMQ__Connections__Default__Port:-5672}
+      RabbitMQ__Connections__Default__UserName: ${RabbitMQ__Connections__Default__UserName:-test}
+      RabbitMQ__Connections__Default__Password: ${RabbitMQ__Connections__Default__Password:-test}
+      RabbitMQ__EventBus__ClientName: ${RabbitMQ__EventBus__ClientName}
+      RabbitMQ__EventBus__ExchangeName: ${RabbitMQ__EventBus__ExchangeName}
       Redis__Configuration: ${Redis__Configuration}
     depends_on:
       - mongodb
@@ -385,12 +406,12 @@ services:
       # App__DcOptions__3__Cdn: ${App__DcOptions__3__Cdn}
       # App__DcOptions__3__MediaOnly: ${App__DcOptions__3__MediaOnly}
       # App__DcOptions__3__Static: ${App__DcOptions__3__Static}
-      RabbitMQ__Connections__Default__HostName: ${RabbitMQ__Connections__Default__HostName}
-      # RabbitMQ__Connections__Default__Port: ${RabbitMQ__Connections__Default__Port}
-      # RabbitMQ__Connections__Default__UserName: ${RabbitMQ__Connections__Default__UserName}
-      # RabbitMQ__Connections__Default__Password: ${RabbitMQ__Connections__Default__Password}
-      # RabbitMQ__EventBus__ClientName: ${RabbitMQ__EventBus__ClientName}
-      # RabbitMQ__EventBus__ExchangeName: ${RabbitMQ__EventBus__ExchangeName}
+      RabbitMQ__Connections__Default__HostName: ${RabbitMQ__Connections__Default__HostName:-rabbitmq}
+      RabbitMQ__Connections__Default__Port: ${RabbitMQ__Connections__Default__Port:-5672}
+      RabbitMQ__Connections__Default__UserName: ${RabbitMQ__Connections__Default__UserName:-test}
+      RabbitMQ__Connections__Default__Password: ${RabbitMQ__Connections__Default__Password:-test}
+      RabbitMQ__EventBus__ClientName: ${RabbitMQ__EventBus__ClientName}
+      RabbitMQ__EventBus__ExchangeName: ${RabbitMQ__EventBus__ExchangeName}
       Redis__Configuration: ${Redis__Configuration}
     volumes:
       - ./data/mytelegram/command-server/logs:/app/Logs
@@ -475,12 +496,12 @@ services:
       # App__DcOptions__3__Cdn: ${App__DcOptions__3__Cdn}
       # App__DcOptions__3__MediaOnly: ${App__DcOptions__3__MediaOnly}
       # App__DcOptions__3__Static: ${App__DcOptions__3__Static}
-      RabbitMQ__Connections__Default__HostName: ${RabbitMQ__Connections__Default__HostName}
-      # RabbitMQ__Connections__Default__Port: ${RabbitMQ__Connections__Default__Port}
-      # RabbitMQ__Connections__Default__UserName: ${RabbitMQ__Connections__Default__UserName}
-      # RabbitMQ__Connections__Default__Password: ${RabbitMQ__Connections__Default__Password}
-      # RabbitMQ__EventBus__ClientName: ${RabbitMQ__EventBus__ClientName}
-      # RabbitMQ__EventBus__ExchangeName: ${RabbitMQ__EventBus__ExchangeName}
+      RabbitMQ__Connections__Default__HostName: ${RabbitMQ__Connections__Default__HostName:-rabbitmq}
+      RabbitMQ__Connections__Default__Port: ${RabbitMQ__Connections__Default__Port:-5672}
+      RabbitMQ__Connections__Default__UserName: ${RabbitMQ__Connections__Default__UserName:-test}
+      RabbitMQ__Connections__Default__Password: ${RabbitMQ__Connections__Default__Password:-test}
+      RabbitMQ__EventBus__ClientName: ${RabbitMQ__EventBus__ClientName}
+      RabbitMQ__EventBus__ExchangeName: ${RabbitMQ__EventBus__ExchangeName}
       Redis__Configuration: ${Redis__Configuration}
     volumes:
       - ./data/mytelegram/query-server/logs:/app/Logs
@@ -506,12 +527,12 @@ services:
       # VonageSms__BrandName: ${VonageSms__BrandName}
       # VonageSms__ApiKey: ${VonageSms__ApiKey}
       # VonageSms__ApiSecret: ${VonageSms__ApiSecret}
-      RabbitMQ__Connections__Default__HostName: ${RabbitMQ__Connections__Default__HostName}
-      # RabbitMQ__Connections__Default__Port: ${RabbitMQ__Connections__Default__Port}
-      # RabbitMQ__Connections__Default__UserName: ${RabbitMQ__Connections__Default__UserName}
-      # RabbitMQ__Connections__Default__Password: ${RabbitMQ__Connections__Default__Password}
-      # RabbitMQ__EventBus__ClientName: ${RabbitMQ__EventBus__ClientName}
-      # RabbitMQ__EventBus__ExchangeName: ${RabbitMQ__EventBus__ExchangeName}
+      RabbitMQ__Connections__Default__HostName: ${RabbitMQ__Connections__Default__HostName:-rabbitmq}
+      RabbitMQ__Connections__Default__Port: ${RabbitMQ__Connections__Default__Port:-5672}
+      RabbitMQ__Connections__Default__UserName: ${RabbitMQ__Connections__Default__UserName:-test}
+      RabbitMQ__Connections__Default__Password: ${RabbitMQ__Connections__Default__Password:-test}
+      RabbitMQ__EventBus__ClientName: ${RabbitMQ__EventBus__ClientName}
+      RabbitMQ__EventBus__ExchangeName: ${RabbitMQ__EventBus__ExchangeName}
     volumes:
       - ./data/mytelegram/sms-sender/logs:/app/Logs
     depends_on:


### PR DESCRIPTION
## **Changelog**

### **Improvements & Updates**

* **Redis**

    * Updated image from `redis:alpine` → `redis:8-alpine`.
    * Added persistent configuration: `--appendonly yes` and snapshot saving (`--save 60 1000`).
    * Added **healthcheck** with `redis-cli ping`.
    * Removed direct port mapping in favor of network-only access.
    * Added commented-out optional authentication config with `REDIS_PASSWORD`.

* **RabbitMQ**

    * Added fallback default values for `RABBITMQ_DEFAULT_USER` and `RABBITMQ_DEFAULT_PASS` using environment variable syntax.
    * Added `RABBITMQ_ERLANG_COOKIE` environment variable with default value.
    * Added **healthcheck** using `rabbitmq-diagnostics ping`.

* **MongoDB**

    * Updated image from `mongo:latest` → `mongo:8`.
    * Explicitly mounted `/data/db` and `/data/configdb` volumes.
    * Added **healthcheck** using `mongosh` ping.
    * Removed unnecessary direct port mapping for better isolation.

* **MinIO**

    * Added **healthcheck** using `curl` to `/minio/health/live`.

* **Docker Compose Orchestration & Startup Reliability**

    * Updated the `depends_on` configuration for all application services to enforce a reliable startup order.
    * Services now use `condition: service_healthy` to wait until dependencies (Redis, RabbitMQ, MongoDB) are fully operational before launching. This eliminates race conditions and connection errors during initial startup.

* **General RabbitMQ Env Config**

    * Updated multiple services to set RabbitMQ connection environment variables with **default fallback values** (`rabbitmq`, `5672`, `test`).
    * Applied to: `data-seeder`, `auth-server`, `session-server`, `gateway-server`, `file-server`, `messenger-command-server`, `messenger-query-server`, and `sms-sender`.

* **Consistency & Security**

    * Removed unused/commented port mappings for better security.
    * Standardized healthchecks and environment variable defaults across services.
    * Replaced `chmod -R 777 ./data/mytelegram` with `chown -R 1654:1654 ./data/mytelegram` to ensure proper ownership instead of insecure global permissions.