### PR TITLE
Add support for pluralized language strings (TLangPackStringPluralized)

### DIFF
--- a/source/src/MyTelegram.Messenger/Handlers/LatestLayer/Impl/Langpack/GetDifferenceHandler.cs
+++ b/source/src/MyTelegram.Messenger/Handlers/LatestLayer/Impl/Langpack/GetDifferenceHandler.cs
@@ -21,11 +21,7 @@ internal sealed class GetDifferenceHandler(ILanguageCacheService languageCacheSe
         {
             FromVersion = obj.FromVersion,
             LangCode = obj.LangCode,
-            Strings = [.. texts.Select(p => new TLangPackString
-            {
-                Key = p.Key,
-                Value = p.Value
-            })],
+            Strings = languageCacheService.ConvertToILangPackString(texts),
             Version = version
         };
 

--- a/source/src/MyTelegram.Messenger/Handlers/LatestLayer/Impl/Langpack/GetLangPackHandler.cs
+++ b/source/src/MyTelegram.Messenger/Handlers/LatestLayer/Impl/Langpack/GetLangPackHandler.cs
@@ -29,11 +29,7 @@ internal sealed class GetLangPackHandler(ILanguageCacheService languageCacheServ
             FromVersion = 0,
             LangCode = obj.LangCode,
             Version = languageReadModel!.LanguageVersion,
-            Strings = [.. texts.Select(p => new TLangPackString
-            {
-                Key = p.Key,
-                Value = p.Value
-            })]
+            Strings = languageCacheService.ConvertToILangPackString(texts)
         };
 
         return langPackDifference;

--- a/source/src/MyTelegram.Messenger/Handlers/LatestLayer/Impl/Langpack/GetStringsHandler.cs
+++ b/source/src/MyTelegram.Messenger/Handlers/LatestLayer/Impl/Langpack/GetStringsHandler.cs
@@ -14,25 +14,25 @@ internal sealed class GetStringsHandler(ILanguageCacheService languageCacheServi
     protected override async Task<TVector<ILangPackString>> HandleCoreAsync(IRequestInput input,
         MyTelegram.Schema.Langpack.RequestGetStrings obj)
     {
-        var texts = (await languageCacheService.GetLanguageTextsAsync(obj.LangCode, obj.LangPack, obj.Keys)).ToDictionary(k => k.Key, v => v);
-        var langPackStrings = new TVector<ILangPackString>();
+        var foundLanguageItems = await languageCacheService.GetLanguageTextsAsync(obj.LangCode, obj.LangPack, obj.Keys);
+        var langPackStrings = languageCacheService.ConvertToILangPackString(foundLanguageItems);
 
-        foreach (var key in obj.Keys)
+        // 3. Identify which keys were NOT found and add them as "Deleted".
+        if (foundLanguageItems.Count != obj.Keys.Count)
         {
-            if (texts.TryGetValue(key, out var item))
+            // Create a HashSet of found keys for efficient lookups (O(1) complexity).
+            var foundKeys = foundLanguageItems.Select(item => item.Key).ToHashSet();
+
+            foreach (var requestedKey in obj.Keys)
             {
-                langPackStrings.Add(new TLangPackString
+                // If the requested key is not in our set of found keys, it's missing.
+                if (!foundKeys.Contains(requestedKey))
                 {
-                    Key = item.Key,
-                    Value = item.Value
-                });
-            }
-            else
-            {
-                langPackStrings.Add(new TLangPackStringDeleted
-                {
-                    Key = key
-                });
+                    langPackStrings.Add(new TLangPackStringDeleted
+                    {
+                        Key = requestedKey
+                    });
+                }
             }
         }
 

--- a/source/src/MyTelegram.Messenger/Services/Caching/LanguageCacheService.cs
+++ b/source/src/MyTelegram.Messenger/Services/Caching/LanguageCacheService.cs
@@ -57,7 +57,11 @@ public class LanguageCacheService(IQueryProcessor queryProcessor, ILogger<Langua
         _languageTexts = languageTexts.GroupBy(p => new { p.LanguageCode, p.Platform },
                 v => new LanguageTextItem(v.Key, v.LanguageVersion) {
                     Value = v.Value,
+                    ZeroValue = v.ZeroValue,
                     OneValue = v.OneValue,
+                    TwoValue = v.TwoValue,
+                    FewValue = v.FewValue,
+                    ManyValue = v.ManyValue,
                     OtherValue = v.OtherValue
                 })
             .ToFrozenDictionary(k => GetLanguageTextKey(k.Key.LanguageCode, k.Key.Platform, false),
@@ -250,3 +254,4 @@ public class LanguageCacheService(IQueryProcessor queryProcessor, ILogger<Langua
         return langCode;
     }
 }
+

--- a/source/src/MyTelegram.Messenger/Services/Caching/LanguageCacheService.cs
+++ b/source/src/MyTelegram.Messenger/Services/Caching/LanguageCacheService.cs
@@ -2,10 +2,16 @@
 
 namespace MyTelegram.Messenger.Services.Caching;
 
-public class LanguageTextItem(string key, string value, int languageVersion)
+public class LanguageTextItem(string key, int languageVersion)
 {
     public string Key { get; init; } = key;
-    public string Value { get; set; } = value;
+    public string? Value { get; set; } = null;
+    public string? ZeroValue { get; set; } = null;
+    public string? OneValue { get; set; } = null;
+    public string? TwoValue { get; set; } = null;
+    public string? FewValue { get; set; } = null;
+    public string? ManyValue { get; set; } = null;
+    public string? OtherValue { get; set; } = null;
     public int LanguageVersion { get; } = languageVersion;
 }
 
@@ -26,6 +32,7 @@ public interface ILanguageCacheService
     Task<ILanguageReadModel?> GetLanguageAsync(string languageCode, string languagePack);
 
     Task<List<LanguageTextItem>> GetLanguageDifferenceAsync(string languageCode, string languagePack, int fromVersion);
+    TVector<ILangPackString> ConvertToILangPackString(IReadOnlyCollection<LanguageTextItem> languageTexts);
 }
 
 public class LanguageCacheService(IQueryProcessor queryProcessor, ILogger<LanguageCacheService> logger) : ILanguageCacheService, ISingletonDependency
@@ -48,7 +55,11 @@ public class LanguageCacheService(IQueryProcessor queryProcessor, ILogger<Langua
         var sw = Stopwatch.StartNew();
         var languageTexts = await queryProcessor.ProcessAsync(new GetAllLanguageTextsQuery());
         _languageTexts = languageTexts.GroupBy(p => new { p.LanguageCode, p.Platform },
-                v => new LanguageTextItem(v.Key, v.Value, v.LanguageVersion))
+                v => new LanguageTextItem(v.Key, v.LanguageVersion) {
+                    Value = v.Value,
+                    OneValue = v.OneValue,
+                    OtherValue = v.OtherValue
+                })
             .ToFrozenDictionary(k => GetLanguageTextKey(k.Key.LanguageCode, k.Key.Platform, false),
                 v => v.ToDictionary(k1 => k1.Key, v1 => v1));
         sw.Stop();
@@ -186,6 +197,46 @@ public class LanguageCacheService(IQueryProcessor queryProcessor, ILogger<Langua
         }
 
         return Task.FromResult<List<LanguageTextItem>>([]);
+    }
+
+    public TVector<ILangPackString> ConvertToILangPackString(IReadOnlyCollection<LanguageTextItem> languageTexts)
+    {
+        var vector = new TVector<ILangPackString>();
+
+        foreach (var item in languageTexts)
+        {
+            if (item.Value != null)
+            {
+                // Single value -> TLangPackString
+                vector.Add(new TLangPackString
+                {
+                    Key = item.Key,
+                    Value = item.Value
+                });
+            }
+            else if (item.ZeroValue != null ||
+                     item.OneValue != null ||
+                     item.TwoValue != null ||
+                     item.FewValue != null ||
+                     item.ManyValue != null ||
+                     item.OtherValue != null)
+            {
+                // Pluralized values -> TLangPackStringPluralized
+                vector.Add(new TLangPackStringPluralized
+                {
+                    Key = item.Key,
+                    ZeroValue = item.ZeroValue,
+                    OneValue = item.OneValue,
+                    TwoValue = item.TwoValue,
+                    FewValue = item.FewValue,
+                    ManyValue = item.ManyValue,
+                    OtherValue = item.OtherValue
+                });
+            }
+            // else -> skip (nothing to map)
+        }
+
+        return vector;
     }
 
     private string GetLanguageCode(string langCode)

--- a/source/src/MyTelegram.ReadModel.Interfaces/ILanguageTextReadModel.cs
+++ b/source/src/MyTelegram.ReadModel.Interfaces/ILanguageTextReadModel.cs
@@ -5,6 +5,12 @@ public interface ILanguageTextReadModel : IReadModel
     DeviceType Platform { get; }
     string LanguageCode { get; }
     string Key { get; }
-    string Value { get; }
+    string? Value { get; }
+    string? ZeroValue { get; }
+    string? OneValue { get; }
+    string? TwoValue { get; }
+    string? FewValue { get; }
+    string? ManyValue { get; }
+    string? OtherValue { get; }
     int LanguageVersion { get; }
 }

--- a/source/src/MyTelegram.ReadModel/Impl/LanguageTextReadModel.cs
+++ b/source/src/MyTelegram.ReadModel/Impl/LanguageTextReadModel.cs
@@ -8,9 +8,14 @@ public class LanguageTextReadModel : ILanguageTextReadModel,
     public DeviceType Platform { get; private set; }
     public string LanguageCode { get; private set; } = null!;
     public string Key { get; private set; } = null!;
-    public string Value { get; private set; } = null!;
+    public string? Value { get; private set; } = null;
+    public string? ZeroValue { get; private set; } = null;
+    public string? OneValue { get; private set; } = null;
+    public string? TwoValue { get; private set; } = null;
+    public string? FewValue { get; private set; } = null;
+    public string? ManyValue { get; private set; } = null;
+    public string? OtherValue { get; private set; } = null;
     public int LanguageVersion { get; private set; }
-
     public virtual string Id { get; private set; } = null!;
     public virtual long? Version { get; set; }
     public Task ApplyAsync(IReadModelContext context, IDomainEvent<LanguageTextAggregate, LanguageTextId, LanguageTextCreatedEvent> domainEvent, CancellationToken cancellationToken)


### PR DESCRIPTION
This PR introduces support for pluralized language strings in the language cache and handlers.

Key changes:
- Updated `LanguageTextItem` and `ILanguageTextReadModel` to include plural forms: ZeroValue, OneValue, TwoValue, FewValue, ManyValue, OtherValue.
- Implemented `LanguageCacheService.ConvertToILangPackString` to convert both single-value and pluralized translations into appropriate `ILangPackString` types.
- Updated `GetStringsHandler`, `GetLangPackHandler`, and `GetDifferenceHandler` to use the new conversion method.
- Ensures that deleted keys are still returned as `TLangPackStringDeleted`.
- Preserves existing behavior for single-value strings (`TLangPackString`) while supporting pluralized forms (`TLangPackStringPluralized`).

This improves language pack handling, enabling accurate representation of plural forms in translations.
